### PR TITLE
Will now skip over symbolic links

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,11 @@ function getDirectories(basePath) {
   return fs
     .readdirSync(basePath)
     .filter(function(file) {
-      var isDir = fs.statSync(path.join(basePath, file)).isDirectory();
+      var stats = fs.lstatSync(path.join(basePath, file));
+      if (stats.isSymbolicLink()) {
+        return false;
+      }
+      var isDir = stats.isDirectory();
       var isNotDotFile = path.basename(file).indexOf('.') !== 0;
       return isDir && isNotDotFile;
     })

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -17,6 +17,9 @@ describe('inquirer-directory', function() {
       },
       'zfolder2': {},
       'some.png': new Buffer([8, 6, 7, 5, 3, 0, 9]),
+      'a-symlink': mock.symlink({
+        path: 'folder1'
+      })
     });
   });
 


### PR DESCRIPTION
Previously, the package would error would error whenever a symbolic link was encountered in directory. I switch to used [`lstatSync`](https://nodejs.org/api/fs.html#fs_class_fs_stats) so I could test of the presence of a symbolic link.

I thought it would be easiest to just skip over them.

I also added a mock symbolic link to your test data. The tests correctly fail without the fix.
