### PR TITLE
feat(vim-nav): add vim style navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ npm install --save inquirer-directory
 ```
 
 ## Features
-- Support for hidden and symlinked files
+- Support for symlinked files
 - Vim style navigation
 - Search for file with "/" key
+
+### Key Maps
+- Press "/" key to enter search mode.
+- Press "-" key to go up (back) a directory.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Relative Directory prompt for [inquirer](https://github.com/SBoudrias/Inquirer.j
 npm install --save inquirer-directory
 ```
 
+## Features
+- Support for hidden and symlinked files
+- Vim style navigation
+- Search for file with "/" key
+
 ## Usage
 
 

--- a/index.js
+++ b/index.js
@@ -70,11 +70,11 @@ Prompt.prototype._run = function( cb ) {
   var events = observe(this.rl);
 
   var keyUps = events.keypress.filter(function (e) {
-    return !self.searchMode && (e.key.name === 'up' || e.key.name === 'k');
+    return e.key.name === 'up' || (!self.searchMode && e.key.name === 'k');
   }).share();
 
   var keyDowns = events.keypress.filter(function (e) {
-    return !self.searchMode && (e.key.name === 'down' || e.key.name === 'j');
+    return e.key.name === 'down' || (!self.searchMode && e.key.name === 'j');
   }).share();
 
   var keySlash = events.keypress.filter(function (e) {

--- a/index.js
+++ b/index.js
@@ -108,7 +108,6 @@ Prompt.prototype._run = function( cb ) {
     })
     .takeUntil(done$)
     .doOnCompleted(function() {
-      console.log('COMPLETED');
       self.searchMode = false;
       self.render();
       return false;
@@ -121,7 +120,7 @@ Prompt.prototype._run = function( cb ) {
   keyUps.takeUntil( outcome.done ).forEach( this.onUpKey.bind(this) );
   keyDowns.takeUntil( outcome.done ).forEach( this.onDownKey.bind(this) );
   keyMinus.takeUntil( outcome.done ).forEach( this.handleBack.bind(this) );
-  alphaNumeric.takeUntil( outcome.done ).forEach( this.hideKeyPress.bind(this) );
+  events.keypress.takeUntil( outcome.done ).forEach( this.hideKeyPress.bind(this) );
   searchTerm.takeUntil( outcome.done ).forEach( this.onKeyPress.bind(this) );
   outcome.done.forEach( this.onSubmit.bind(this) );
 
@@ -157,6 +156,8 @@ Prompt.prototype.render = function() {
   }
   if (this.searchMode) {
     message += ("\nSearch: " + this.searchTerm);
+  } else {
+    message += "\n(Use \"/\" key to search this directory)";
   }
 
   this.firstRender = false;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "figures": "^1.4.0",
     "inquirer": "^0.11.0",
     "lodash": "^3.10.1",
+    "rx-lite": "^4.0.8",
     "util": "^0.10.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I've added "vim" style navigation AND kept the search functionality by
requiring users to enter "search mode" be pressing the "/" key.

BREAKING CHANGE:
pressing a letter to jump to file name no longer works. To use that
functionality, you must use "search mode" by pressing "/" key.
